### PR TITLE
Fix for Root Dockerfile building from Dockerhub not source and also adjusting Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN apk --no-cache add libgcc libstdc++ ca-certificates curl jq && update-ca-cer
 
 COPY --from=backend /go/bin/statping /usr/local/bin/
 COPY --from=backend /root/sassc/bin/sassc /usr/local/bin/
+COPY --from=backend /usr/local/share/ca-certificates /usr/local/share/
 
 WORKDIR /app
 VOLUME /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,53 @@
-FROM adamboutcher/statping-ng:base AS base
+FROM node:12.18.2-alpine AS frontend
+LABEL maintainer="Statping-ng (https://github.com/statping-ng)"
 ARG BUILDPLATFORM
-# Statping main Docker image that contains all required libraries
-FROM alpine:latest
+WORKDIR /statping
+COPY ./frontend/package.json .
+COPY ./frontend/yarn.lock .
+RUN yarn install --pure-lockfile --network-timeout 1000000
+COPY ./frontend .
+RUN yarn build && yarn cache clean
+
+# Statping Golang BACKEND building from source
+# Creates "/go/bin/statping" and "/usr/local/bin/sass" for copying
+FROM golang:1.14-alpine AS backend
+LABEL maintainer="Statping-NG (https://github.com/statping-ng)"
+ARG VERSION
+ARG COMMIT
+ARG BUILDPLATFORM
+ARG TARGETARCH
+RUN apk add --update --no-cache libstdc++ gcc g++ make git autoconf \
+    libtool ca-certificates linux-headers wget curl jq && \
+    update-ca-certificates
+
+WORKDIR /root
+RUN git clone https://github.com/sass/sassc.git
+RUN . sassc/script/bootstrap && make -C sassc -j4
+# sassc binary: /root/sassc/bin/sassc
+
+WORKDIR /go/src/github.com/statping-ng/statping-ng
+ADD go.mod go.sum ./
+RUN go mod download
+ENV GO111MODULE on
+ENV CGO_ENABLED 1
+RUN go get github.com/stretchr/testify/assert && \
+    go get github.com/stretchr/testify/require && \
+	go get github.com/GeertJohan/go.rice/rice && \
+	go get github.com/cortesi/modd/cmd/modd && \
+	go get github.com/crazy-max/xgo
+COPY . .
+COPY --from=frontend /statping/dist/ ./source/dist/
+RUN make clean generate embed
+RUN go build -a -ldflags "-s -w -extldflags -static -X main.VERSION=${VERSION} -X main.COMMIT=${COMMIT}" -o statping --tags "netgo linux" ./cmd
+RUN chmod a+x statping && mv statping /go/bin/statping
+# /go/bin/statping - statping binary
+# /root/sassc/bin/sassc - sass binary
+# /statping - Vue frontend (from frontend)
+
 RUN apk --no-cache add libgcc libstdc++ ca-certificates curl jq && update-ca-certificates
 
-COPY --from=base /go/bin/statping /usr/local/bin/
-COPY --from=base /root/sassc/bin/sassc /usr/local/bin/
-COPY --from=base /usr/local/share/ca-certificates /usr/local/share/
+RUN cp /go/bin/statping /usr/local/bin/
+RUN cp /root/sassc/bin/sassc /usr/local/bin/
 
 WORKDIR /app
 VOLUME /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN chmod a+x statping && mv statping /go/bin/statping
 # /root/sassc/bin/sassc - sass binary
 # /statping - Vue frontend (from frontend)
 
+# Statping main Docker image that contains all required libraries
 FROM alpine:latest
 
 RUN apk --no-cache add libgcc libstdc++ ca-certificates curl jq && update-ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,12 @@ RUN chmod a+x statping && mv statping /go/bin/statping
 # /root/sassc/bin/sassc - sass binary
 # /statping - Vue frontend (from frontend)
 
+FROM alpine:latest
+
 RUN apk --no-cache add libgcc libstdc++ ca-certificates curl jq && update-ca-certificates
 
-RUN cp /go/bin/statping /usr/local/bin/
-RUN cp /root/sassc/bin/sassc /usr/local/bin/
+COPY --from=backend /go/bin/statping /usr/local/bin/
+COPY --from=backend /root/sassc/bin/sassc /usr/local/bin/
 
 WORKDIR /app
 VOLUME /app

--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,10 @@ db-down:
 console:
 	docker exec -t -i statping /bin/sh
 
-compose-build-full: docker-base
+compose-build-full: 
 	docker-compose -f docker-compose.yml -f dev/docker-compose.full.yml build --parallel --build-arg VERSION=${VERSION}
 
-docker-base:
-	docker build -t statping-ng/statping-ng:base -f Dockerfile.base --build-arg VERSION=${VERSION} .
-
-docker-latest: docker-base
+docker-latest: 
 	docker build -t statping-ng/statping-ng:latest --build-arg VERSION=${VERSION} .
 
 docker-vue:
@@ -125,13 +122,6 @@ docker-vue:
 
 docker-test:
 	docker-compose -f docker-compose.test.yml up --remove-orphans
-
-push-base: clean compile docker-base
-	docker push statping-ng/statping-ng:base
-
-push-vue: clean compile docker-base docker-vue
-	docker push statping-ng/statping-ng:base
-	docker push statping-ng/statping-ng:vue
 
 modd:
 	modd -f ./dev/modd.conf
@@ -285,16 +275,9 @@ download-key:
 	wget -O statping.gpg $(SIGN_URL)
 	gpg --import statping.gpg
 
-# push the :dev docker tag using curl
-dockerhub-dev:
-	docker build --build-arg VERSION=${VERSION} -t statping-ng/statping-ng:dev --no-cache -f Dockerfile.base .
-	docker push statping-ng/statping-ng:dev
-
 dockerhub:
-	docker build --build-arg VERSION=${VERSION} -t statping-ng/statping-ng:base --no-cache -f Dockerfile.base .
 	docker build --build-arg VERSION=${VERSION} -t statping-ng/statping-ng:latest --no-cache -f Dockerfile .
 	docker tag statping-ng/statping-ng statping-ng/statping-ng:v${VERSION}
-	docker push statping-ng/statping-ng:base
 	docker push statping-ng/statping-ng:v${VERSION}
 	docker push statping-ng/statping-ng
 
@@ -392,12 +375,6 @@ buildx-dev: multiarch
 	docker buildx build --builder statping-dev --cache-from "type=local,src=/tmp/.buildx-cache" --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 -f Dockerfile -t adamboutcher/statping-ng:dev --build-arg=VERSION=${VERSION} --build-arg=COMMIT=${COMMIT} .
 	docker buildx rm statping-dev
 
-buildx-base: multiarch
-	docker buildx create --name statping-base --driver-opt image=moby/buildkit:master
-	docker buildx inspect --builder statping-base --bootstrap
-	docker buildx build --builder statping-base --cache-from "type=local,src=/tmp/.buildx-cache" --cache-to "type=local,dest=/tmp/.buildx-cache,mode=max" --push --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6 -f Dockerfile.base -t adamboutcher/statping-ng:base --build-arg=VERSION=${VERSION} --build-arg=COMMIT=${COMMIT} .
-	docker buildx rm statping-base
-
 multiarch:
 	mkdir /tmp/.buildx-cache || true
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -426,5 +403,5 @@ gen_help:
 		marked -o html/$file.html $file --gfm
 	done
 
-.PHONY: all check build certs multiarch install-darwin go-build build-all buildx-base buildx-dev buildx-latest build-alpine test-all test test-api docker frontend up down print_details lite sentry-release snapcraft build-linux build-mac build-win build-all postman
+.PHONY: all check build certs multiarch install-darwin go-build build-all buildx-dev buildx-latest build-alpine test-all test test-api docker frontend up down print_details lite sentry-release snapcraft build-linux build-mac build-win build-all postman
 .SILENT: travis_s3_creds

--- a/Makefile
+++ b/Makefile
@@ -273,10 +273,10 @@ download-key:
 	gpg --import statping.gpg
 
 dockerhub:
-	docker build --build-arg VERSION=${VERSION} -t statping-ng/statping-ng:latest --no-cache -f Dockerfile .
-	docker tag statping-ng/statping-ng statping-ng/statping-ng:v${VERSION}
-	docker push statping-ng/statping-ng:v${VERSION}
-	docker push statping-ng/statping-ng
+	docker build --build-arg VERSION=${VERSION} -t adamboutcher/statping-ng:latest --no-cache -f Dockerfile .
+	docker tag adamboutcher/statping-ng adamboutcher/statping-ng:v${VERSION}
+	docker push adamboutcher/statping-ng:v${VERSION}
+	docker push adamboutcher/statping-ng
 
 docker-build-dev:
 	docker build --build-arg VERSION=${VERSION} -t statping-ng/statping-ng:latest --no-cache -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,6 @@ compose-build-full:
 docker-latest: 
 	docker build -t statping-ng/statping-ng:latest --build-arg VERSION=${VERSION} .
 
-docker-vue:
-	docker build -t statping-ng/statping-ng:vue --build-arg VERSION=${VERSION} .
-
 docker-test:
 	docker-compose -f docker-compose.test.yml up --remove-orphans
 

--- a/dev/docker-compose.lite.yml
+++ b/dev/docker-compose.lite.yml
@@ -4,7 +4,7 @@ services:
 
   statping_dev:
     container_name: statping_dev
-    image: statping/statping:dev
+    image: statping-ng/statping-ng:dev
     restart: on-failure
     volumes:
       - ./cmd:/go/src/github.com/statping-ng/statping-ng/cmd/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 services:
   statping:
     container_name: statping
-    image: aboutcher/statping-ng:dev
+    image: adamboutcher/statping-ng:latest
     restart: always
     volumes:
       - statping_data:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 services:
   statping:
     container_name: statping
-    image: statping-ng/statping-ng:dev
+    image: aboutcher/statping-ng:dev
     restart: always
     volumes:
       - statping_data:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2.3'
 services:
   statping:
     container_name: statping
-    image: aboutcher/statping-ng:dev
+    image: statping-ng/statping-ng:dev
     restart: always
     volumes:
       - statping_data:/app


### PR DESCRIPTION
Idk if there was some configuration error on my side. 
But for me it looked like dev/docker-compose.full.yml was using the Dockerfiles from the root directory because of which it pulled directly from Dockerhub which is kinda useless in dev.
only fixes docker-compose -f docker-compose.full.yml up/build

deleted whole dev/dockerfile.dev (which was not working at all) and copied stuff over from dockerfile.base and dockerfile