### PR TITLE
Remove snapcraft as a statping service

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,7 +25,6 @@ architectures:
 apps:
   statping:
     command: bin/statping
-    daemon: simple
     plugs:
       - home
       - network


### PR DESCRIPTION
Fixes issues with Snapcraft Auto-builds (Removed service).