### PR TITLE
Allow chat_ids for telegram notifications

### DIFF
--- a/frontend/src/forms/Notifier.vue
+++ b/frontend/src/forms/Notifier.vue
@@ -282,7 +282,7 @@ export default {
         this.notifier.form.forEach((f) => {
           let field = f.field.toLowerCase()
           let val = this.notifier[field]
-          if (this.isNumeric(val)) {
+          if (this.isNumeric(val) && (this.form.method!='telegram' && field != 'var1')) {
             val = parseInt(val)
           }
           this.form[field] = val
@@ -304,7 +304,7 @@ export default {
         this.notifier.form.forEach((f) => {
           let field = f.field.toLowerCase()
           let val = this.notifier[field]
-          if (this.isNumeric(val)) {
+          if (this.isNumeric(val) && (this.form.method!='telegram' && field != 'var1')) {
             val = parseInt(val)
           }
           this.form[field] = val

--- a/frontend/src/forms/Notifier.vue
+++ b/frontend/src/forms/Notifier.vue
@@ -282,7 +282,7 @@ export default {
         this.notifier.form.forEach((f) => {
           let field = f.field.toLowerCase()
           let val = this.notifier[field]
-          if (this.isNumeric(val) && (this.form.method!='telegram' && field != 'var1')) {
+          if (this.isNumeric(val) && this.form.method!='telegram') {
             val = parseInt(val)
           }
           this.form[field] = val
@@ -304,7 +304,7 @@ export default {
         this.notifier.form.forEach((f) => {
           let field = f.field.toLowerCase()
           let val = this.notifier[field]
-          if (this.isNumeric(val) && (this.form.method!='telegram' && field != 'var1')) {
+          if (this.isNumeric(val) && this.form.method!='telegram') {
             val = parseInt(val)
           }
           this.form[field] = val

--- a/notifiers/telegram.go
+++ b/notifiers/telegram.go
@@ -52,8 +52,8 @@ var Telegram = &telegram{&notifications.Notification{
 	}, {
 		Type:        "text",
 		Title:       "Channel",
-		Placeholder: "@statping_channel",
-		SmallText:   "Insert your Telegram Channel including the @ symbol. The bot will need to be an administrator of this channel.",
+		Placeholder: "@statping_channel/-123123512312",
+		SmallText:   "Insert your Telegram Channel including the @ symbol. The bot will need to be an administrator of this channel. You can also supply a chat_id.",
 		DbField:     "var1",
 		Required:    true,
 	}}},


### PR DESCRIPTION
Allow chat_ids in notifier. Currently you can not supply chat_ids for telegram notifications. This results in the inability to use private channels or groups for notifications.