### PR TITLE
Branding updates and CDN Changes.

### DIFF
--- a/frontend/public/base.gohtml
+++ b/frontend/public/base.gohtml
@@ -25,7 +25,7 @@
     <meta property="twitter:description" content="{{CoreApp.Description}} {{CoreApp.Name}}">
 
     {{if USE_CDN}}
-    <link rel="stylesheet" href="https://assets.statping.com/css/vendor.css">
+    <link rel="stylesheet" href="https://statping-ng.github.io/assets/hosted/vendor.css" />
     {{else}}
     <% _.each(htmlWebpackPlugin.tags.headTags, function(headTag) { %>
     <%= headTag %> <% }) %>
@@ -39,10 +39,10 @@
 <div id="app" class="statping_container"></div>
 
 {{if USE_CDN}}
-<script src="https://assets.statping.com/js/bundle.js"></script>
-<script src="https://assets.statping.com/js/vendor.chunk.js"></script>
-<script src="https://assets.statping.com/js/polyfill.chunk.js"></script>
-<script src="https://assets.statping.com/js/main.chunk.js"></script>
+<script src="https://statping-ng.github.io/assets/hosted/bundle.js"></script>
+<script src="https://statping-ng.github.io/assets/hosted/vendor.chunk.js"></script>
+<script src="https://statping-ng.github.io/assets/hosted/polyfill.chunk.js"></script>
+<script src="https://statping-ng.github.io/assets/hosted/main.chunk.js"></script>
 {{else}}
 <% _.each(htmlWebpackPlugin.tags.bodyTags, function(bodyTag) { %>
 <%= bodyTag %> <% }) %>

--- a/frontend/src/components/Dashboard/TopNav.vue
+++ b/frontend/src/components/Dashboard/TopNav.vue
@@ -1,6 +1,6 @@
 <template>
     <nav class="navbar navbar-expand-lg">
-        <router-link to="/" class="navbar-brand">Statping</router-link>
+        <router-link to="/" class="navbar-brand">Statping-ng</router-link>
         <button @click="navopen = !navopen" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText" aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
             <font-awesome-icon v-if="!navopen" icon="bars"/>
             <font-awesome-icon v-if="navopen" icon="times"/>


### PR DESCRIPTION
This PR updates the header from statping to statping-ng.

This PR removes assets.statping.com as the CDN and changes ti to statping-ng.github.io this is for privacy (only MS then collect usage) and remove reliance on a quiet 3rd party.