### PR TITLE
Fixed arguments being passed to utils.Command for Command Notifier

### DIFF
--- a/notifiers/command.go
+++ b/notifiers/command.go
@@ -43,6 +43,10 @@ var Command = &commandLine{&notifications.Notification{
 func runCommand(cmd string) (string, string, error) {
 	
 	utils.Log.Infof("Command notifier sending: %s", cmd)
+	
+	if len(cmd) == 0 {
+		return "", "", errors.New("you need at least 1 command")
+	}
 
         file, errt := ioutil.TempFile(os.TempDir(), "statping-exec.*.sh")
 

--- a/notifiers/command.go
+++ b/notifiers/command.go
@@ -41,17 +41,28 @@ var Command = &commandLine{&notifications.Notification{
 }}
 
 func runCommand(cmd string) (string, string, error) {
-	utils.Log.Infof("Command notifier sending: %s", cmd)
-	cmdApp := strings.Split(cmd, " ")
-	if len(cmd) == 0 {
-		return "", "", errors.New("you need at least 1 command")
-	}
-	var cmdArgs []string
-	if len(cmd) > 1 {
-		cmdArgs = append(cmdArgs, cmd[1:])
-	}
-	outStr, errStr, err := utils.Command(cmdApp[0], cmdArgs...)
-	return outStr, errStr, err
+        utils.Log.Infof("Command notifier sending: %s", cmd)
+        cmdApp := strings.Fields(cmd)
+
+        if len(cmd) == 0 {
+               	return "", "", errors.New("you need at least 1 command")
+        }
+
+        var cmdArgs []string
+
+        if len(cmdApp) > 1 {
+               	cmdArgs = cmdApp[1:]
+        }
+
+        outStr, errStr, err := utils.Command(cmdApp[0], cmdArgs...)
+
+        if(err!=nil){
+
+        utils.Log.Errorf("Run Error %s",err)
+
+        }
+
+        return outStr, errStr, err
 }
 
 // OnSuccess for commandLine will trigger successful service

--- a/types/services/methods.go
+++ b/types/services/methods.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"github.com/statping-ng/statping-ng/types"
 	"github.com/statping-ng/statping-ng/types/errors"
 	"github.com/statping-ng/statping-ng/types/failures"
@@ -199,6 +200,18 @@ func humanMicro(val int64) string {
 	}
 	return fmt.Sprintf("%0.0f ms", float64(val)*0.001)
 }
+//returns just the host of the service, used in templating command notifier
+func (s Service) Host() (string) {
+
+     u, err := url.Parse(s.Domain)
+
+     if (err!=nil) {
+      return s.Domain
+     }
+
+     return u.Host
+}
+
 
 // IsRunning returns true if the service go routine is running
 func (s *Service) IsRunning() bool {


### PR DESCRIPTION
The way the cmd string was being parsed result in utils.Command getting the following call 
utils.Command("binary-to-call",[]string{"binary-to-call other args here"}, this properly removes the duplicate