### PR TITLE
Permit the healthcheck to work if a BASE_PATH is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,10 @@ ENV IS_DOCKER=true
 ENV SASS=/usr/local/bin/sassc
 ENV STATPING_DIR=/app
 ENV PORT=8080
+ENV BASE_PATH=""
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD curl -s "http://localhost:$PORT/health" | jq -r -e ".online==true"
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD if [ -z "$BASE_PATH" ]; then HEALTHPATH="/health"; else HEALTHPATH="/$BASE_PATH/health" ; fi && curl -s "http://localhost:80$HEALTHPATH" | jq -r -e ".online==true"
 
 CMD statping --port $PORT


### PR DESCRIPTION
You can set the environment variable `BASE_PATH=statping` so that https://yoursite.domain:1234/statping/ is how the app is accessed.  This is common behind reverse proxies.  Note that a forward-slash is not used (which would otherwise allow just the variable to be dropped in).

In order to do that, the healthcheck, which does not obey BASE_PATH, must be disabled. This should make it continue to work.