### PR TITLE
fix: log search error

### DIFF
--- a/frontend/src/pages/Logs.vue
+++ b/frontend/src/pages/Logs.vue
@@ -61,7 +61,7 @@ export default {
           const ts = data.match(/[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9]/gm)
           return {
             time: ts[0],
-            message: data.split(ts+": ")[1]
+            message: data.split(ts+": ")[1] || ''
           }
         },
         cleanLog(l) {


### PR DESCRIPTION
# Issue

We met error when try to search the logs:

TypeError: Cannot read properties of undefined (reading 'includes')
    at /js/dashboard.chunk.js:1:42599
    at Array.filter (<anonymous>)
    at o.logs (/js/dashboard.chunk.js:1:42563)
    at hn.get (vendor.chunk.js:7:26396)
    at hn.evaluate (vendor.chunk.js:7:27546)
    at o.logs (vendor.chunk.js:7:28311)
    at o.<anonymous> (/js/dashboard.chunk.js:1:44726)
    at o.t._render (vendor.chunk.js:7:34407)
    at o.hn.before (vendor.chunk.js:7:64010)
    at hn.get (vendor.chunk.js:7:26396)

# Root Cause

There might be some line of log doesn't match the log rule. so we need to make those log message to be a default empty string. so that we can call `.include` on the empty string to bypass this error