### PR TITLE
Go 17 build

### DIFF
--- a/.github/workflows/1_dev.yml
+++ b/.github/workflows/1_dev.yml
@@ -63,7 +63,7 @@ jobs:
         arch: [386, amd64, arm-7, arm-6, arm64]
         include:
           - platform: darwin
-            arch: arm64
+            arch: 386
           - platform: darwin
             arch: amd64
           - platform: windows

--- a/.github/workflows/1_dev.yml
+++ b/.github/workflows/1_dev.yml
@@ -63,7 +63,7 @@ jobs:
         arch: [386, amd64, arm-7, arm-6, arm64]
         include:
           - platform: darwin
-            arch: 386
+            arch: arm64
           - platform: darwin
             arch: amd64
           - platform: windows

--- a/.github/workflows/2_unstable.yml
+++ b/.github/workflows/2_unstable.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
       - uses: actions/setup-node@v1
         with:
           node-version: 16.14.0
@@ -109,7 +109,7 @@ jobs:
           COMMIT: ${{ github.sha }}
         with:
           xgo_version: latest
-          go_version: 1.15.x
+          go_version: 1.17.x
           dest: build
           prefix: statping
           targets: ${{ matrix.platform }}/${{ matrix.arch }}
@@ -196,7 +196,7 @@ jobs:
 #      - uses: actions/checkout@v2
 #      - uses: actions/setup-go@v2
 #        with:
-#          go-version: 1.15.x
+#          go-version: 1.17.x
 #      - uses: actions/setup-node@v1
 #        with:
 #          node-version: 16.14.0
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |
@@ -334,7 +334,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |
@@ -391,7 +391,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |

--- a/.github/workflows/3_stable.yml
+++ b/.github/workflows/3_stable.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
       - uses: actions/setup-node@v1
         with:
           node-version: 16.14.0
@@ -129,7 +129,7 @@ jobs:
           COMMIT: ${{ github.sha }}
         with:
           xgo_version: latest
-          go_version: 1.15.x
+          go_version: 1.17.x
           dest: build
           prefix: statping
           targets: ${{ matrix.platform }}/${{ matrix.arch }}
@@ -219,7 +219,7 @@ jobs:
 #      - uses: actions/checkout@v2
 #      - uses: actions/setup-go@v2
 #        with:
-#          go-version: 1.15.x
+#          go-version: 1.17.x
 #      - uses: actions/setup-node@v1
 #        with:
 #          node-version: 16.14.0
@@ -303,7 +303,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |
@@ -357,7 +357,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |
@@ -414,7 +414,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.17.x
 
       - name: Setting ENV's
         run: |


### PR DESCRIPTION
Updates the go version to 1.17.x on the build (Dev, Unstable, Stable) scripts.