### PR TITLE
Add HEAD method to services

### DIFF
--- a/frontend/src/forms/Service.vue
+++ b/frontend/src/forms/Service.vue
@@ -94,12 +94,13 @@
                 <div class="col-sm-8">
                     <select v-model="service.method" name="method" class="form-control">
                         <option value="GET" >GET</option>
+                        <option value="HEAD" >HEAD</option>
                         <option value="POST" >POST</option>
                         <option value="DELETE" >DELETE</option>
                         <option value="PATCH" >PATCH</option>
                         <option value="PUT" >PUT</option>
                     </select>
-                    <small class="form-text text-muted">A GET request will simply request the endpoint, you can also send data with POST.</small>
+                    <small class="form-text text-muted">A GET/HEAD request will simply request the endpoint, you can also send data with POST.</small>
                 </div>
             </div>
 


### PR DESCRIPTION
So services can use the HEAD method to check websites. This has the added benefit of not loading big pages and thus being more lightweight.

closes #143 