### PR TITLE
Removed Reporting options from the WebUI and API

### DIFF
--- a/frontend/src/API.js
+++ b/frontend/src/API.js
@@ -18,9 +18,6 @@ class Api {
 
   async core() {
     const core = axios.get('api').then(response => (response.data))
-    if (core.allow_reports) {
-      await this.sentry_init()
-    }
     return core
   }
 

--- a/frontend/src/forms/CoreSettings.vue
+++ b/frontend/src/forms/CoreSettings.vue
@@ -50,19 +50,6 @@
                     </select>
                 </div>
 
-                <div class="form-group row mt-3">
-                    <label class="col-sm-10 col-form-label">{{ $t('send_reports') }}</label>
-                    <div class="col-sm-2 float-right">
-                        <span @click="core.allow_reports = !!core.allow_reports" class="switch" id="allow_report">
-                        <input v-model="core.allow_reports" type="checkbox" name="allow_report" class="switch" id="switch_allow_report" :checked="core.allow_reports">
-                        <label for="switch_allow_report"></label>
-                      </span>
-                    </div>
-                    <div class="col-12">
-                        <small>{{ $t('send_reports_desc') }}</small>
-                    </div>
-                </div>
-
         </div>
         <div class="card-footer">
             <button @click.prevent="saveSettings" id="save_core" type="submit" class="btn btn-primary btn-block" v-bind:disabled="loading">

--- a/frontend/src/forms/Setup.vue
+++ b/frontend/src/forms/Setup.vue
@@ -58,19 +58,6 @@
                             <input @keyup="canSubmit" v-model="setup.db_database" id="db_database" type="text" class="form-control" placeholder="Database name">
                         </div>
 
-                        <div class="form-group mt-3">
-                            <div class="row">
-                                <div class="col-9">
-                                    <span class="text-left text-capitalize">{{ $t('send_reports') }}</span>
-                                </div>
-                                <div class="col-3 text-right">
-                                    <span @click="setup.send_reports = !!setup.send_reports" class="switch">
-                                      <input v-model="setup.send_reports" type="checkbox" name="send_reports" class="switch" id="send_reports" :checked="setup.send_reports">
-                                      <label for="send_reports"></label>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
 
                     </div>
 
@@ -113,13 +100,7 @@
                                     <label class="text-capitalize">{{ $t('email') }}</label>
                                     <input @keyup="canSubmit" v-model="setup.email" id="email" type="text" class="form-control" placeholder="myemail@domain.com">
                                 </div>
-                                <div class="col-4 text-right">
-                                    <label class="d-none d-sm-block text-capitalize text-capitalize">{{ $t('newsletter') }}</label>
-                                    <span @click="setup.newsletter = !!setup.newsletter" class="switch">
-                                      <input v-model="setup.newsletter" type="checkbox" name="send_newsletter" class="switch" id="send_newsletter" :checked="setup.newsletter">
-                                      <label for="send_newsletter"></label>
-                                    </span>
-                                </div>
+                                <div class="col-4 text-right">&nbsp;</div>
                             </div>
                             <small>{{ $t('newsletter_note') }}</small>
                         </div>
@@ -167,8 +148,8 @@
         password: "",
         confirm_password: "",
         sample_data: true,
-        newsletter: true,
-        send_reports: true,
+        newsletter: false,
+        send_reports: false,
         email: "",
       }
     }

--- a/frontend/src/pages/Help.vue
+++ b/frontend/src/pages/Help.vue
@@ -435,7 +435,7 @@ services:
 <li><code>GO_ENV</code>                    - Run Statping in testmode, will bypass HTTP authentication (if set as &lsquo;test&rsquo;)</li>
 <li><code>REMOVE_AFTER</code>              - Automatically delete records after time (default 3 months, &lsquo;12h = 12 hours&rsquo;)</li>
 <li><code>CLEANUP_INTERVAL</code>          - Interval to check for old records (default 1 hour, &lsquo;1h = 1 hour&rsquo;)</li>
-<li><code>ALLOW_REPORTS</code>             - Send Statping anonymous <a href="https://sentry.io/" target="_blank">error reports</a> so we can see issues (default is false)</li>
+<li><code>ALLOW_REPORTS</code>             - Send Statping anonymous <a href="https://sentry.io/" target="_blank">error reports</a> so we can see issues (default is false) - Should be removed in Statping-ng</li>
 <li><code>SERVER_PORT</code>               - Port number to run Statping HTTP server on (or use -p/&ndash;port)</li>
 </ul>
 


### PR DESCRIPTION
This is my attempt to remove the "Reporting" from the WebUI, it also removes the "Newsletter" from the initial setup and ensures both are set to false by default.

As this removes the ability for the user to change the settings and it /might/ leak data, please double check the source if privacy is key.

Part of the ongoing effort to remove deps/pings from the original statping.