### PR TITLE
feat: enhance email notification to send alerts to multiple recipients

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,4 @@ Dockerfile.base
 !dev/prometheus.yml
 docker
 statping.db
+statup

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ tmp
 /frontend/cypress/videos/
 services.yml
 statping.wiki
-statup
+statup/

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ tmp
 /frontend/cypress/videos/
 services.yml
 statping.wiki
+statup

--- a/notifiers/email.go
+++ b/notifiers/email.go
@@ -3,6 +3,7 @@ package notifiers
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/go-mail/mail"
 	"github.com/statping-ng/emails"
@@ -163,7 +164,13 @@ func (e *emailer) dialSend(email *emailOutgoing) error {
 	}
 
 	m.SetAddressHeader("From", email.From, "Statping")
-	m.SetHeader("To", email.To)
+	//For sending emails to multiple recipients that are comma separated
+	tempSplit := strings.Split(email.To, ",")
+	addresses := make([]string, len(tempSplit))
+	for i := range addresses {
+		addresses[i] = m.FormatAddress(tempSplit[i], "")
+	}
+	m.SetHeader("To", addresses...)
 	m.SetHeader("Subject", email.Subject)
 	m.SetBody("text/html", email.Template)
 

--- a/notifiers/email.go
+++ b/notifiers/email.go
@@ -165,11 +165,7 @@ func (e *emailer) dialSend(email *emailOutgoing) error {
 
 	m.SetAddressHeader("From", email.From, "Statping")
 	//For sending emails to multiple recipients that are comma separated
-	tempSplit := strings.Split(email.To, ",")
-	addresses := make([]string, len(tempSplit))
-	for i := range addresses {
-		addresses[i] = m.FormatAddress(tempSplit[i], "")
-	}
+	addresses := strings.Split(email.To, ",")
 	m.SetHeader("To", addresses...)
 	m.SetHeader("Subject", email.Subject)
 	m.SetBody("text/html", email.Template)


### PR DESCRIPTION
This PR enhances the email notification functionality where email alerts can now take a set of email addresses separated by comma.
This is related to this github issue #171 