### PR TITLE
remove push.statping.com from sample services

### DIFF
--- a/types/services/samples.go
+++ b/types/services/samples.go
@@ -159,7 +159,7 @@ func Samples() error {
 
 	s6 := &Service{
 		Name:      "Private Service",
-		Domain:    "https://push.statping.com",
+		Domain:    "https://example.org",
 		Method:    "GET",
 		Interval:  30,
 		Type:      "http",


### PR DESCRIPTION
it's down so the service will always report as offline.
also, removing dependency on original statping

this has caused some unnecessary confusion in the past (see #121)

(also whoops sorry for pushing to this repo and possibly sending extra notifs - I got trolled by the github web editor)