### PR TITLE
Move messages to the top of status page

### DIFF
--- a/frontend/src/pages/Index.vue
+++ b/frontend/src/pages/Index.vue
@@ -12,27 +12,28 @@
         </div>
       </div>
 
-        <div class="col-12 full-col-12">
-            <div v-for="service in services_no_group" v-bind:key="service.id" class="list-group online_list mb-4">
-                <div class="list-group-item list-group-item-action">
-                    <router-link class="no-decoration font-3" :to="serviceLink(service)">{{service.name}}</router-link>
-                    <span class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
-                    <GroupServiceFailures :service="service"/>
-                    <IncidentsBlock :service="service"/>
-                </div>
-            </div>
-        </div>
+      <div class="col-12 full-col-12">
+          <MessageBlock v-for="message in messages" v-bind:key="message.id" :message="message" />
+      </div>
+
+      <div class="col-12 full-col-12">
+          <div v-for="service in services_no_group" v-bind:key="service.id" class="list-group online_list mb-4">
+              <div class="list-group-item list-group-item-action">
+                  <router-link class="no-decoration font-3" :to="serviceLink(service)">{{service.name}}</router-link>
+                  <span class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
+                  <GroupServiceFailures :service="service"/>
+                  <IncidentsBlock :service="service"/>
+              </div>
+          </div>
+      </div>
 
       <Group v-for="group in groups" v-bind:key="group.id" :group=group />
-        <div class="col-12 full-col-12">
-            <MessageBlock v-for="message in messages" v-bind:key="message.id" :message="message" />
-        </div>
 
-        <div class="col-12 full-col-12">
-            <div v-for="service in services" :ref="service.id" v-bind:key="service.id">
-                <ServiceBlock :service="service" />
-            </div>
-        </div>
+      <div class="col-12 full-col-12">
+          <div v-for="service in services" :ref="service.id" v-bind:key="service.id">
+              <ServiceBlock :service="service" />
+          </div>
+      </div>
 
     </div>
 </template>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -3,13 +3,13 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/statping-ng/statping-ng/types/errors"
 	"html/template"
 	"net/http"
 	"path"
 	"time"
 
 	"github.com/statping-ng/statping-ng/source"
+	"github.com/statping-ng/statping-ng/types/errors"
 	"github.com/statping-ng/statping-ng/utils"
 )
 


### PR DESCRIPTION
Moves messages to the top of the status page instead of halfway down
Fixes https://github.com/statping-ng/statping-ng/issues/181

Will add the read only user fix as a separate PR as it is more complex