### PR TITLE
Make all services and groups available via the API (#69)

### DIFF
--- a/CloudronManifest.json
+++ b/CloudronManifest.json
@@ -16,4 +16,4 @@
   "icon": "https://assets.statping.com/icon.png",
   "tags": [ "monitoring", "uptime" ],
   "mediaLinks": [ "https://assets.statping.com/cloudron.png" ]
-}s
+}

--- a/handlers/groups.go
+++ b/handlers/groups.go
@@ -29,8 +29,8 @@ func findGroup(r *http.Request) (*groups.Group, error) {
 
 // apiAllGroupHandler will show all the groups
 func apiAllGroupHandler(r *http.Request) interface{} {
-	auth, admin := IsUser(r), IsAdmin(r)
-	return groups.SelectGroups(admin, auth)
+	auth, isAdmin := IsUser(r), IsAdmin(r) || hasAuthorizationHeader(r)
+	return groups.SelectGroups(isAdmin, auth)
 }
 
 // apiGroupHandler will show a single group

--- a/handlers/services.go
+++ b/handlers/services.go
@@ -269,7 +269,8 @@ func apiServiceDeleteHandler(w http.ResponseWriter, r *http.Request) {
 func apiAllServicesHandler(r *http.Request) interface{} {
 	var srvs []services.Service
 	for _, v := range services.AllInOrder() {
-		if !v.Public.Bool && !IsUser(r) {
+		// Skip service if its private and no user, admin or API token is authenticated
+		if !v.Public.Bool && !IsUser(r) && !hasAuthorizationHeader(r) {
 			continue
 		}
 		srvs = append(srvs, v)

--- a/utils/utils_custom.go
+++ b/utils/utils_custom.go
@@ -6,10 +6,6 @@ package utils
 import (
 	"errors"
 	"os"
-	"os/exec"
-	"regexp"
-	"strconv"
-	"strings"
 	"syscall"
 )
 


### PR DESCRIPTION
I think this is a needed fix, because external services or scripts should have access to all data. If there is a use case where an API token should not access private data, different token permissions should probably be implemented.

I tested this the following way:

- Created a clean setup with demo data.
- Added a new test user.
- Logged in with both users, both can view private services and groups on the dashboard.
- Anonymous users can not view private services or groups on the dashboard.
- When authenticated with an API token, private services and groups are now displayed properly.

Of course, this should be pointed out in the release notes.

---

Testing locally can be done by building the binary. With Go and Node installed, run `make build`. Then start Statping with `./statping`.  
API testing can be done by setting an API secret right before starting Statping with `export  API_SECRET=super-secret-token`. In a tool like [Insomnia](https://insomnia.rest/), you can point to `http://localhost:8080/api/services` with the secret as a Bearer token.