### PR TITLE
Add all possible target platforms to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,7 +452,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
           push_strategy: artifact
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm/v7, linux/arm/v6, linux/arm64
           args: |
             COMMIT=${{ github.sha }}
             VERSION=${{ needs.data.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,11 +106,10 @@ jobs:
         platform: [ linux ]
         arch: [ 386, amd64, arm-7, arm-6, arm64 ]
         include:
-          # TODO darwin/386 is broken, ignore for now
-          # - platform: darwin
-          #   arch: 386
           - platform: darwin
             arch: amd64
+          - platform: darwin
+            arch: arm64
           - platform: windows
             arch: amd64
           - platform: windows


### PR DESCRIPTION
quoting from an [earlier comment](https://github.com/statping-ng/statping-ng/pull/222#issuecomment-1605698800):

I just played around with xgo a bit and here's what I found out about broken builds:
* `darwin/386` was [dropped with go 1.15](https://go.dev/doc/go1.15#darwin) - xgo reports a rather ominous "go version too high" if you try it anyway
* the same announcement also hints that `amd64` and `arm64` are the only supported targets for darwin. since those already work, darwin builds already work as well as they possibly could
* all targets work on linux (😎)
* windows: [crazy-max' goxx](https://github.com/crazy-max/goxx#supported-platforms) only supports `windows/386` and `windows/amd64`, which both work here already

additionally, build docker images for amd64 and arm 6 to 8.

TODO:
- [x] try i386 docker image again -> not supported (no node image)
- [x] squash commits to hide my inability to spell