### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG VERSION
 ARG COMMIT
 ARG BUILDPLATFORM
 ARG TARGETARCH
-RUN apk add --update --no-cache libstdc++ gcc g++ make git autoconf \
+RUN apk add --no-cache libstdc++ gcc g++ make git autoconf \
     libtool ca-certificates linux-headers wget curl jq && \
     update-ca-certificates
 


### PR DESCRIPTION
The `--no-cache` option in Alpine Linux's `apk` makes `--update` redundant, leading to unnecessary temporary files in the Docker image. This redundancy should be removed for a cleaner image.