### PR TITLE
Fix Docker Build (issue with go-sqlite3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn build && yarn cache clean
 
 # Statping Golang BACKEND building from source
 # Creates "/go/bin/statping" and "/usr/local/bin/sass" for copying
-FROM golang:1.20-alpine AS backend
+FROM golang:1.20.0-alpine AS backend
 LABEL maintainer="Statping-NG (https://github.com/statping-ng)"
 ARG VERSION
 ARG COMMIT


### PR DESCRIPTION
**Bug:** In a new version of Alpine they updated an internal library which then broke the Go library `mattn/go-sqlite3`. Golang automatically pulled in this new version of alpine when rebuilding the `1.20` release, which is causing the builds to now fail.

**Short Term Fix:** By pinning the image to `1.20.0-alpine` instead of just `1.20-alpine` we are grabbing an older built image that does not experience this issue. This maintains compatibility with all current code and requires no other changes.

**Long Term Fix:** Update the library version for `mattn/go-sqlite3` to one that includes the patch.

**See here for more detail: https://github.com/mattn/go-sqlite3/pull/1177#issuecomment-1849176090**


# Changelog
## Fixed
- Dockerfile is now able to build
## Changed
- Pin the golang image we build with to `golang:1.20.0-alpine`.