### PR TITLE
Fix broken healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,6 @@ ENV BASE_PATH=""
 
 EXPOSE $PORT
 
-HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD if [ -z "$BASE_PATH" ]; then HEALTHPATH="/health"; else HEALTHPATH="/$BASE_PATH/health" ; fi && curl -s "http://localhost:80$HEALTHPATH" | jq -r -e ".online==true"
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 CMD if [ -z "$BASE_PATH" ]; then HEALTHPATH="/health"; else HEALTHPATH="/$BASE_PATH/health" ; fi && curl -s "http://localhost:${PORT}$HEALTHPATH" | jq -r -e ".online==true"
 
 CMD statping --port $PORT


### PR DESCRIPTION
The healthcheck fails because it tried to connect to port 80 instead of the configured port.