### PR TITLE
Add header validation to prevent service panic.

### DIFF
--- a/types/services/routine.go
+++ b/types/services/routine.go
@@ -335,6 +335,9 @@ func CheckSmtp(s *Service, record bool) (*Service, error) {
 
 	// check if 'Content-Type' header was defined
 	for _, header := range headers {
+		if len(strings.Split(header, "=")) < 2 {
+			continue
+		}
 		switch strings.ToLower(strings.Split(header, "=")[0]) {
 		case "username":
 			username = strings.Split(header, "=")[1]
@@ -447,6 +450,9 @@ func CheckImap(s *Service, record bool) (*Service, error) {
 
 	// check if 'Content-Type' header was defined
 	for _, header := range headers {
+		if len(strings.Split(header, "=")) < 2 {
+			continue
+		}
 		switch strings.ToLower(strings.Split(header, "=")[0]) {
 		case "username":
 			username = strings.Split(header, "=")[1]
@@ -547,6 +553,9 @@ func CheckHttp(s *Service, record bool) (*Service, error) {
 
 	// check if 'Content-Type' header was defined
 	for _, header := range headers {
+		if len(strings.Split(header, "=")) < 2 {
+			continue
+		}
 		if strings.Split(header, "=")[0] == "Content-Type" {
 			contentType = strings.Split(header, "=")[1]
 			break


### PR DESCRIPTION
if user set header xxx without "="，services will crash due to array overflow. 
So, I made the following modifications to check the validity of the header.