### PR TITLE
Add command service type for running a command and checking exit code, stdout and stderr

### DIFF
--- a/types/errors/common.go
+++ b/types/errors/common.go
@@ -22,6 +22,30 @@ var (
 		Err:  "ID needs to be an integer",
 		Code: 422,
 	}
+	ServiceNameMissing = &appError{
+		Err:  "missing service name",
+		Code: 422,
+	}
+	ServiceTypeMissing = &appError{
+		Err:  "missing service type",
+		Code: 422,
+	}
+	DomainNameMissing = &appError{
+		Err:  "missing domain name",
+		Code: 422,
+	}
+	CheckIntervalMissing = &appError{
+		Err:  "missing check interval",
+		Code: 422,
+	}
+	CommandConfigNotJson = &appError{
+		Err:  "command config not JSON",
+		Code: 422,
+	}
+	CommandConfigFieldCmdMissing = &appError{
+		Err:  "command config field \"Cmd\" missing",
+		Code: 422,
+	}
 )
 
 func Missing(object interface{}, id interface{}) error {

--- a/types/services/command.go
+++ b/types/services/command.go
@@ -1,0 +1,19 @@
+package services
+
+type CmdConfig struct {
+	Cmd     string
+	Args    []string
+	Dir     string
+	Stdin   string
+	Env     map[string]string
+	Stdout  string
+	Stderr  string
+}
+
+type CmdResult struct {
+	isErr       bool
+	errMsg      string
+	ExitCode    int
+	Stdout      string
+	Stderr      string
+}


### PR DESCRIPTION
**The command service's config format:**
```
{
  "Cmd": "_CMD_PATH_(required)",
  "Args": [_ARGS_LIST_(optional)],
  "Dir": "_DIR_PATH_(optional)",
  "Env": {_ENV_VARS_MAP_(optional)},
  "Stdin": "_STDIN_STR_(optional)",
  "Stdout": "_STDOUT_REGEX_(optional)",
  "Stderr": "_STDERR_REGEX_(optional)"
}
```

**Example:**
```
{
  "Cmd": "/usr/bin/ping",
  "Args": ["-c", "1", "-W", "1", "example.com"],
  "Stdout": ".+1 received.+"
}
```

**Example:**
```
{
  "Cmd": "/bin/bash",
  "Args": ["-c", "/usr/bin/ping -c 1 -W 1 example.com"]
}
```