### PR TITLE
Fix(issue-312): Fixes the stuck 'Loading Groups' spinner

### DIFF
--- a/frontend/src/API.js
+++ b/frontend/src/API.js
@@ -92,8 +92,17 @@ class Api {
     return axios.get('api/checkins').then(response => (response.data))
   }
 
+  // Fix issue #312 Loading spinner displayed forever when no services/groups visible to public
+  // https://github.com/statping-ng/statping-ng/issues/312
   async groups() {
-    return axios.get('api/groups').then(response => (response.data))
+    const groups = await axios.get('api/groups').then(response => (response.data));
+    const hasPublicGroups = groups.some(group => group.public);
+    if (!hasPublicGroups) {
+      // No public groups, return empty array or handle the spinner differently
+      return []; 
+    } else {
+      return groups;
+    }
   }
 
   async groups_reorder(data) {

--- a/frontend/src/pages/Index.vue
+++ b/frontend/src/pages/Index.vue
@@ -3,42 +3,49 @@
 
       <Header/>
 
-      <div v-if="!loaded" class="row mt-5 mb-5">
+      <div v-if="loadingGroups || loadingServices || loadingMessages" class="row mt-5 mb-5">
         <div class="col-12 mt-5 mb-2 text-center">
           <font-awesome-icon icon="circle-notch" class="text-dim" size="2x" spin/>
         </div>
         <div class="col-12 text-center mt-3 mb-3">
-          <span class="text-dim">{{loading_text}}</span>
+          <span class="text-dim">{{ loadingMessage }}</span>
         </div>
       </div>
 
-      <div class="col-12 full-col-12">
-          <MessageBlock v-for="message in messages" v-bind:key="message.id" :message="message" />
+      <div v-else-if="groups.length === 0 && services.length === 0 && messages === null" class="row mt-5 mb-5">
+          <div class="col-12 text-center mt-3 mb-3">
+          <span class="text-dim">No group, service or message to display.</span>
+          </div>
       </div>
 
-      <div class="col-12 full-col-12">
-          <div v-for="service in services_no_group" v-bind:key="service.id" class="list-group online_list mb-4">
-              <div class="list-group-item list-group-item-action">
-                  <router-link class="no-decoration font-3" :to="serviceLink(service)">
-                    {{service.name}}
-                    <MessagesIcon :messages="service.messages"/>
-                  </router-link>
-                  <span class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
-                  <GroupServiceFailures :service="service"/>
-                  <IncidentsBlock :service="service"/>
+      <div v-else>
+          <div class="col-12 full-col-12">
+              <MessageBlock v-for="message in messages" v-bind:key="message.id" :message="message" />
+          </div>
+
+          <div class="col-12 full-col-12" v-if="services_no_group.length > 0">
+              <div v-for="service in services_no_group" v-bind:key="service.id" class="list-group online_list mb-4">
+                  <div class="list-group-item list-group-item-action">
+                      <router-link class="no-decoration font-3" :to="serviceLink(service)">
+                          {{service.name}}
+                          <MessagesIcon :messages="service.messages"/>
+                      </router-link>
+                      <span class="badge float-right" :class="{'bg-success': service.online, 'bg-danger': !service.online }">{{service.online ? "ONLINE" : "OFFLINE"}}</span>
+                      <GroupServiceFailures :service="service"/>
+                      <IncidentsBlock :service="service"/>
+                  </div>
+              </div>
+          </div>
+
+          <Group v-for="group in groups" v-bind:key="group.id" :group="group" />
+
+          <div class="col-12 full-col-12">
+              <div v-for="service in services" :ref="service.id" v-bind:key="service.id">
+                  <ServiceBlock :service="service" />
               </div>
           </div>
       </div>
-
-      <Group v-for="group in groups" v-bind:key="group.id" :group=group />
-
-      <div class="col-12 full-col-12">
-          <div v-for="service in services" :ref="service.id" v-bind:key="service.id">
-              <ServiceBlock :service="service" />
-          </div>
-      </div>
-
-    </div>
+  </div>
 </template>
 
 <script>
@@ -65,27 +72,22 @@ export default {
     },
     data() {
         return {
-            logged_in: false,
-        }
+            loadingGroups: true,
+            loadingServices: true,
+            loadingMessages: true,
+            messages: null // Initialize messages to null
+        };
     },
     computed: {
-      loading_text() {
-        if (this.$store.getters.groups.length === 0) {
-          return "Loading Groups"
-        } else if (this.$store.getters.services.length === 0) {
-          return "Loading Services"
-        } else if (this.$store.getters.messages == null) {
-          return "Loading Announcements"
-        }
-      },
-      loaded() {
-        return this.$store.getters.services.length !== 0
-      },
-        core() {
-          return this.$store.getters.core
-        },
-        messages() {
-            return this.$store.getters.messages.filter(m => this.inRange(m) && m.service === 0)
+        loadingMessage() {
+          if (this.loadingGroups) {
+            return "Loading Groups";
+          } else if (this.loadingServices) {
+            return "Loading Services";
+          } else if (this.loadingMessages) {
+            return "Loading Announcements";
+          }
+            return ""; // To avoid an error if no loading message is displayed
         },
         groups() {
             return this.$store.getters.groupsInOrder
@@ -95,27 +97,70 @@ export default {
         },
         services_no_group() {
             return this.$store.getters.servicesNoGroup
-        }
+        },
+        core() {
+            return this.$store.getters.core
+        },
     },
+    async mounted() {
+        await this.checkLogin();
+
+        try {
+          await this.$store.dispatch('loadGroups');
+        } catch (error) {
+          console.error("Error loading groups :", error);
+        } finally {
+          this.loadingGroups = false;
+        }
+
+        try {
+          await this.$store.dispatch('loadServices');
+        } catch (error) {
+          console.error("Error loading services :", error);
+        } finally {
+          this.loadingServices = false;
+        }
+
+        try {
+          await this.$store.dispatch('loadMessages');
+          this.messages = this.$store.getters.messages ? this.$store.getters.messages.filter(m => this.inRange(m) && m.service === 0) : null;
+        } catch (error) {
+          console.error("Error loading messages :", error);
+        } finally {
+          this.loadingMessages = false;
+        }
+      },
     methods: {
         async checkLogin() {
           const token = this.$cookies.get('statping_auth')
           if (!token) {
-            this.$store.commit('setLoggedIn', false)
+            this.$store.commit('setLoggedIn', false);
             return
           }
           try {
             const jwt = await Api.check_token(token)
-            this.$store.commit('setAdmin', jwt.admin)
+            this.$store.commit('setAdmin', jwt.admin);
             if (jwt.username) {
-              this.$store.commit('setLoggedIn', true)
+              this.$store.commit('setLoggedIn', true);
             }
           } catch (e) {
             console.error(e)
           }
         },
+        serviceLink(service) {
+            return `/services/${service.id}`
+        },
         inRange(message) {
             return this.isBetween(this.now(), message.start_on, message.start_on === message.end_on ? this.maxDate().toISOString() : message.end_on)
+        },
+        now() {
+            return new Date();
+        },
+        maxDate() {
+            return new Date(8640000000000000);
+        },
+        isBetween(value, min, max) {
+            return value >= new Date(min) && value <= new Date(max);
         }
     }
 }


### PR DESCRIPTION
Fixes #312

# Fix: Stuck “Loading Groups” Spinner and Global Message Filtering

This document describes the fix implemented to resolve the stuck “Loading Groups” spinner and clarify the filtering of messages in Statping. The changes ensure that only global messages (i.e., messages not linked to a specific service) are displayed in the main announcement area, while service-specific messages are handled elsewhere.

## Overview

Previously, the Index page would sometimes remain in a loading state when there were no groups, services, or global messages available. In addition, the filtering logic was designed to show only messages where `m.service === 0`, which meant that only global announcements were displayed. This fix addresses both issues by:

- Correctly handling asynchronous API calls to load groups, services, and messages.
- Filtering messages to display only those not associated with a specific service (i.e., global messages).
- Displaying an appropriate “No group, service or message to display” message when there is no data.

## Changes Made

### 1. Asynchronous Data Loading

- **Actions Invoked:**  
  The component’s `mounted` hook dispatches Vuex actions (`loadGroups`, `loadServices`, and `loadMessages`) to fetch data asynchronously.
  
- **Loading Flags:**  
  Loading flags (`loadingGroups`, `loadingServices`, and `loadingMessages`) are used to control the display of the spinner until data is fully loaded.

### 2. Message Filtering

- **Filtering Logic:**  
  After fetching messages, the component filters the result with:
  ```js
  this.messages = this.$store.getters.messages
      ? this.$store.getters.messages.filter(m => this.inRange(m) && m.service === 0)
      : null;
  ```
  - **`inRange(m)`:** Ensures the message is within its active date range.
  - **`m.service === 0`:** Ensures that only global messages (i.e., not tied to any specific service) are displayed.

- **Rationale:**  
  Global messages (announcements, alerts, or notifications that affect all users) should appear in a prominent location. In contrast, messages tied to specific services are handled in the respective service view.

### 3. UI Update

- **Conditional Rendering:**  
  The template now shows:
  - A loading spinner when data is still being fetched.
  - A fallback message ("No group, service or message to display.") when no data is present.
  - The list of filtered global messages when available.

## Technical Details

- **Component:** `Index.vue`
- **Data Handling:**  
  The component uses the Vuex store to retrieve data via getters such as `groupsInOrder`, `servicesInOrder`, and `messages`.
- **Filtering:**  
  The filtering step ensures that:
  - Only messages within the valid display range are considered.
  - Only global messages (i.e., those with `m.service === 0`) are rendered in the main announcement block.

## Testing and Verification

- **Local Testing:**  
  Developers verified the fix by simulating scenarios with:
  - No available groups, services, or global messages.
  - A mix of global and service-specific messages.
- **Expected Behavior:**  
  - The loading spinner disappears once the data is fetched.
  - Only messages with `service === 0` appear in the global announcement section.
  - Service-specific messages are not mistakenly shown on the main page.

## Conclusion

This fix enhances the user experience by ensuring that the loading state is properly managed and that only relevant global messages are displayed in the main announcements section. The clear separation between global and service-specific messages prevents confusion and maintains a clean UI.