### PR TITLE
Update mysql connection string to avoid tzinfo issues

### DIFF
--- a/types/configs/methods.go
+++ b/types/configs/methods.go
@@ -69,7 +69,7 @@ func (d *DbConfig) ConnectionString() string {
 		return d.SqlFile
 	case "mysql":
 		host := fmt.Sprintf("%v:%v", d.DbHost, d.DbPort)
-		conn = fmt.Sprintf("%v:%v@tcp(%v)/%v?charset=utf8&parseTime=True&loc=UTC&time_zone=%%27UTC%%27", d.DbUser, d.DbPass, host, d.DbData)
+		conn = fmt.Sprintf("%v:%v@tcp(%v)/%v?charset=utf8&parseTime=True&loc=UTC&time_zone=%%27%%2B00%%3A00%%27", d.DbUser, d.DbPass, host, d.DbData)
 		return conn
 	case "postgres":
 		conn = fmt.Sprintf("host=%v port=%v user=%v dbname=%v password=%v timezone=UTC sslmode=%v", d.DbHost, d.DbPort, d.DbUser, d.DbData, d.DbPass, postgresSSL)


### PR DESCRIPTION
When mysql server doesn't have `tzinfo` installed the app is unable to connect the DB.

I've changed hardcoded 'UTC' timezone name to '+00:00' zone offset.

Discussion in #139.