### PR TITLE
Fix duplicate submits and improve reliability of incident create/update flow

### DIFF
--- a/frontend/src/components/Dashboard/Incidents.vue
+++ b/frontend/src/components/Dashboard/Incidents.vue
@@ -34,14 +34,13 @@
 
                     <div class="form-group row">
                         <div class="col-sm-12">
-                            <button @click.prevent="createIncident"
-                                    :disabled="!incident.title || !incident.description"
+                            <button :disabled="submitting || !canCreateIncident"
                                     type="submit" class="btn btn-block btn-primary">
-                                Create Incident
+                                {{ submitting ? "Creating Incident..." : "Create Incident" }}
                             </button>
                         </div>
                     </div>
-                    <div class="alert alert-danger d-none" id="alerter" role="alert"></div>
+                    <div v-if="errorMessage" class="alert alert-danger" role="alert">{{ errorMessage }}</div>
                 </form>
             </div>
         </div>
@@ -60,6 +59,8 @@ const FormIncidentUpdates = () => import(/* webpackChunkName: "dashboard" */ '@/
         data() {
             return {
                 serviceID: 0,
+                submitting: false,
+                errorMessage: "",
                 incidents: [],
                 incident: {
                     title: "",
@@ -68,6 +69,11 @@ const FormIncidentUpdates = () => import(/* webpackChunkName: "dashboard" */ '@/
                   }
               }
           },
+    computed: {
+        canCreateIncident() {
+            return this.incident.title.trim().length > 0 && this.incident.description.trim().length > 0
+        }
+    },
 
     created() {
         this.serviceID = Number(this.$route.params.id);
@@ -79,6 +85,25 @@ const FormIncidentUpdates = () => import(/* webpackChunkName: "dashboard" */ '@/
     },
 
     methods: {
+      extractErrorMessage(error, fallback) {
+        const responseData = error?.response?.data || error
+        if (typeof responseData === "string" && responseData.trim()) {
+          return responseData.trim()
+        }
+        if (typeof responseData?.error === "string" && responseData.error.trim()) {
+          return responseData.error
+        }
+        if (responseData?.error?.message) {
+          return responseData.error.message
+        }
+        if (responseData?.message) {
+          return responseData.message
+        }
+        if (error?.message) {
+          return error.message
+        }
+        return fallback
+      },
 
       async delete(i) {
         this.res = await Api.incident_delete(i)
@@ -100,17 +125,44 @@ const FormIncidentUpdates = () => import(/* webpackChunkName: "dashboard" */ '@/
         },
 
         async createIncident() {
-            this.res = await Api.incident_create(this.serviceID, this.incident)
-            if (this.res.status === "success") {
-                this.incidents.push(this.res.output) // this is better in terms of not having to querry the db to get a fresh copy of all updates
-                //await this.loadIncidents()
-            } // TODO: further error checking here... maybe alert user it failed with modal or so
+            if (this.submitting) {
+                return
+            }
 
-            // reset the form data
-            this.incident = {
-                title: "",
-                description: "",
-                service: this.serviceID,
+            const title = this.incident.title.trim()
+            const description = this.incident.description.trim()
+
+            if (!title || !description) {
+                this.errorMessage = "Incident title and description are required."
+                return
+            }
+
+            this.submitting = true
+            this.errorMessage = ""
+
+            try {
+                const response = await Api.incident_create(this.serviceID, {
+                    ...this.incident,
+                    title,
+                    description,
+                    service: this.serviceID,
+                })
+
+                if (response?.status === "success" && response.output) {
+                    this.incidents.push(response.output)
+                    this.incident = {
+                        title: "",
+                        description: "",
+                        service: this.serviceID,
+                    }
+                    return
+                }
+
+                this.errorMessage = this.extractErrorMessage(response, "Unable to create the incident right now.")
+            } catch (error) {
+                this.errorMessage = this.extractErrorMessage(error, "Unable to create the incident right now.")
+            } finally {
+                this.submitting = false
             }
         },
 

--- a/frontend/src/forms/IncidentUpdates.vue
+++ b/frontend/src/forms/IncidentUpdates.vue
@@ -23,13 +23,16 @@
             </div>
 
             <div class="col-12 col-md-2">
-                <button @click.prevent="createIncidentUpdate"
-                        :disabled="!incident_update.message"
+                <button :disabled="submitting || !canSubmit"
                         type="submit" class="btn btn-block btn-primary">
-                    Add
+                    {{ submitting ? "Adding..." : "Add" }}
                 </button>
             </div>
         </form>
+
+        <div v-if="errorMessage" class="alert alert-danger mt-3 mb-0" role="alert">
+            {{ errorMessage }}
+        </div>
 
     </div>
 </template>
@@ -50,11 +53,18 @@
         data () {
             return {
                 updates: [],
+                submitting: false,
+                errorMessage: "",
                 incident_update: {
                     incident: this.incident.id,
                     message: "",
-                    type: "Investigating" // TODO: default to something.. theres is no error checking for blank submission...
+                    type: "Investigating"
                 }
+            }
+        },
+        computed: {
+            canSubmit() {
+                return this.incident_update.message.trim().length > 0
             }
         },
 
@@ -63,20 +73,61 @@
         },
 
         methods: {
+            extractErrorMessage(error, fallback) {
+                const responseData = error?.response?.data || error
+                if (typeof responseData === "string" && responseData.trim()) {
+                    return responseData.trim()
+                }
+                if (typeof responseData?.error === "string" && responseData.error.trim()) {
+                    return responseData.error
+                }
+                if (responseData?.error?.message) {
+                    return responseData.error.message
+                }
+                if (responseData?.message) {
+                    return responseData.message
+                }
+                if (error?.message) {
+                    return error.message
+                }
+                return fallback
+            },
             async createIncidentUpdate() {
-                this.res = await Api.incident_update_create(this.incident_update)
-                if (this.res.status === "success") {
-                    this.updates.push(this.res.output) // this is better in terms of not having to querry the db to get a fresh copy of all updates
-                    //await this.loadUpdates()
-                } // TODO: further error checking here... maybe alert user it failed with modal or so
-
-                // reset the form data
-                this.incident_update = {
-                    incident: this.incident.id,
-                    message: "",
-                    type: "Investigating"
+                if (this.submitting) {
+                    return
                 }
 
+                const message = this.incident_update.message.trim()
+                if (!message) {
+                    this.errorMessage = "Incident update message is required."
+                    return
+                }
+
+                this.submitting = true
+                this.errorMessage = ""
+
+                try {
+                    const response = await Api.incident_update_create({
+                        ...this.incident_update,
+                        message,
+                    })
+
+                    if (response?.status === "success" && response.output) {
+                        this.updates.push(response.output)
+                        this.incident_update = {
+                            incident: this.incident.id,
+                            message: "",
+                            type: "Investigating"
+                        }
+                        return
+                    }
+
+                    this.errorMessage = this.extractErrorMessage(response, "Unable to add the incident update right now.")
+                } catch (error) {
+                    this.errorMessage = this.extractErrorMessage(error, "Unable to add the incident update right now.")
+                } finally {
+                    this.submitting = false
+                }
             },
 
             async loadUpdates() {


### PR DESCRIPTION
…/update flowThis patch improves the reliability of the incident create/update flow in the dashboard without changing backend APIs or architecture.

It focuses on a critical admin workflow: creating incidents and posting updates during outages. The goal is to reduce silent failures, prevent duplicate submissions, and ensure predictable form behavior.

Why this matters

The incident flow is a high-impact user path.
Duplicate submissions and silent failures can lead to:
- inconsistent incident state
- user confusion
- reduced trust in status reporting

This patch makes the flow more predictable and robust.

Summary
- Remove duplicate submission wiring (@submit + @click)
- Prevent repeated submits while a request is in flight
- Validate trimmed input before API calls
- Show inline error feedback on failure
- Reset form only after confirmed success
- Replace TODO-marked error-handling gaps in this flow with real behavior
- No behavior change for successful requests

Testing
- git diff --check passed
- Build not run
- Tests not run

Risk / Scope
- Scope limited to dashboard incident create/update UI
- No backend API changes
- No architectural changes
- No changes to delete flows or unrelated paths
- LF -> CRLF warnings observed but non-blocking